### PR TITLE
Reducing traffic to Memcache while importing new features

### DIFF
--- a/resources/application.conf
+++ b/resources/application.conf
@@ -19,9 +19,9 @@ ktor {
         memcached_client_host = ${?TANK_MEMCACHED_CLIENT_HOST}
         memcached_client_port = 11211
         memcached_client_port = ${?TANK_MEMCACHED_CLIENT_PORT}
-        memcached_enabled = true
+        memcached_enabled = false
         memcached_enabled = ${?TANK_MEMCACHED_ENABLED}
-        cache_region_count = 4
+        cache_region_count = 5
         cache_region_count = ${?TANK_CACHE_REGION_COUNT}
         cache_region_threshold = 300
         cache_region_threshold = ${?TANK_CACHE_REGION_THRESHOLD}

--- a/resources/application.conf
+++ b/resources/application.conf
@@ -19,9 +19,9 @@ ktor {
         memcached_client_host = ${?TANK_MEMCACHED_CLIENT_HOST}
         memcached_client_port = 11211
         memcached_client_port = ${?TANK_MEMCACHED_CLIENT_PORT}
-        memcached_enabled = false
+        memcached_enabled = true
         memcached_enabled = ${?TANK_MEMCACHED_ENABLED}
-        cache_region_count = 5
+        cache_region_count = 3
         cache_region_count = ${?TANK_CACHE_REGION_COUNT}
         cache_region_threshold = 300
         cache_region_threshold = ${?TANK_CACHE_REGION_THRESHOLD}

--- a/resources/application.conf
+++ b/resources/application.conf
@@ -19,8 +19,14 @@ ktor {
         memcached_client_host = ${?TANK_MEMCACHED_CLIENT_HOST}
         memcached_client_port = 11211
         memcached_client_port = ${?TANK_MEMCACHED_CLIENT_PORT}
-        memcached_enabled = false
+        memcached_enabled = true
         memcached_enabled = ${?TANK_MEMCACHED_ENABLED}
+        cache_region_count = 4
+        cache_region_count = ${?TANK_CACHE_REGION_COUNT}
+        cache_region_threshold = 300
+        cache_region_threshold = ${?TANK_CACHE_REGION_THRESHOLD}
+        cache_bounding_threshold = 1000
+        cache_bounding_threshold = ${?TANK_CACHE_BOUNDING_THRESHOLD}
         tyler {
             base_layer = io.marauder.tank
             base_layer = ${?TANK_BASE_LAYER}

--- a/resources/application.conf
+++ b/resources/application.conf
@@ -19,7 +19,7 @@ ktor {
         memcached_client_host = ${?TANK_MEMCACHED_CLIENT_HOST}
         memcached_client_port = 11211
         memcached_client_port = ${?TANK_MEMCACHED_CLIENT_PORT}
-        memcached_enabled = true
+        memcached_enabled = false
         memcached_enabled = ${?TANK_MEMCACHED_ENABLED}
         cache_region_count = 3
         cache_region_count = ${?TANK_CACHE_REGION_COUNT}

--- a/src/main/kotlin/io/marauder/tank/BoundingManager.kt
+++ b/src/main/kotlin/io/marauder/tank/BoundingManager.kt
@@ -1,0 +1,110 @@
+package io.marauder.tank
+
+import io.marauder.charged.models.Feature
+import io.marauder.charged.models.Geometry
+import net.spy.memcached.MemcachedClient
+import org.slf4j.Logger
+import java.util.ArrayList
+
+class BoundingManager (private val cacheBoundingThreshold: Int,
+                       private val memcachedEnabled: Boolean = false,
+                       private val cacheZoomLevelEnd: Int,
+                       private val mcc : MemcachedClient?,
+                       private val log: Logger
+){
+    private val tilingSet = arrayListOf<Tile>()
+
+
+
+    // Debugging
+    private var removeTileRequests = 0
+    private var removeRequests = 0
+    private var featuresImported = 0
+    private var calcTiles = 0
+
+
+    fun add(f: Feature) {
+        if(!memcachedEnabled) return
+
+        featuresImported++
+
+        invalCacheCV(f.geometry)
+
+        if(tilingSet.size >= cacheBoundingThreshold) {
+            clearTilingSet()
+        }
+    }
+
+
+    private fun clearTilingSet() {
+        removeRequests++
+        tilingSet.forEach{t->
+            removeTile(t)
+        }
+        tilingSet.clear()
+    }
+
+
+    fun flush() {
+        if(!memcachedEnabled) return
+        clearTilingSet()
+
+        tilingSet.clear()
+
+        log.info("Tile-Requests = $removeTileRequests  Remove-Requests = $removeRequests  Features-Imported: $featuresImported calculated Tiles= $calcTiles" )
+        removeRequests = 0
+        removeTileRequests = 0
+        featuresImported = 0
+    }
+
+
+    /**
+     * Covering
+     */
+    private fun invalCacheCV(geo : Geometry) {
+        val tileLookUp = ArrayList<Tile>()
+
+        tileLookUp.add(Tile(0,0,0))
+
+        while(tileLookUp.isNotEmpty()) {
+            if(tileLookUp[0].z <= cacheZoomLevelEnd) {
+                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS())) {
+                    invalCacheAllChildren(tileLookUp[0])
+                }
+
+                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
+                    tileLookUp.addAll(tileLookUp[0].getChildren())
+                    if(!tilingSet.contains(tileLookUp[0]))
+                        tilingSet.add(tileLookUp[0])
+                    calcTiles++
+                }
+            }
+            tileLookUp.removeAt(0)
+        }
+    }
+
+    private fun invalCacheAllChildren(t : Tile) {
+        val queue = ArrayList<Tile>()
+
+        queue.add(t)
+
+        while(queue.isNotEmpty()) {
+            if(queue[0].z < cacheZoomLevelEnd) {
+                queue.addAll(queue[0].getChildren())
+            }
+            if(!tilingSet.contains(queue[0]))
+                tilingSet.add(queue[0])
+            queue.removeAt(0)
+            calcTiles++
+        }
+    }
+
+
+    private fun removeTile(t : Tile) {
+        if(memcachedEnabled) {
+            mcc?.delete("heatmap/" + t.z + "/" + t.x + "/" + t.y)
+            mcc?.delete("tile/" + t.z + "/" + t.x + "/" + t.y)
+            removeTileRequests++
+        }
+    }
+}

--- a/src/main/kotlin/io/marauder/tank/Region.kt
+++ b/src/main/kotlin/io/marauder/tank/Region.kt
@@ -1,0 +1,60 @@
+package io.marauder.tank
+
+import io.marauder.charged.Projector
+import io.marauder.charged.models.Feature
+import io.marauder.charged.models.Geometry
+import org.slf4j.Logger
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+
+class Region(
+        private val log: Logger
+) {
+
+    var bbox =  mutableListOf<Double>()
+    private val projector = Projector()
+    private var halfDiameter = 0.0
+    var featureCount = 0
+    var distanceToLastStep = 0
+
+    fun add(f: Feature) = add(f.bbox)
+
+    fun safeAdd(bb: Region?) {
+        if(bb != null){
+            featureCount += bb.featureCount
+            add(bb.bbox)
+        }
+    }
+
+    private fun add(bb: MutableList<Double>) {
+        if(bbox.size == 0) {
+            bbox = bb
+        }
+        else {
+            projector.calcBbox(bBoxToCoordinatList(bb), bbox)
+        }
+        halfDiameter = 0.5 * sqrt((bbox[0] - bbox[2]).pow(2.0) + (bbox[1] - bbox[3]).pow(2.0))
+        featureCount++
+    }
+
+    private fun bBoxToCoordinatList(bounding: List<Double>) = listOf(
+            listOf(bounding[0], bounding[1]),
+            listOf(bounding[0], bounding[3]),
+            listOf(bounding[2], bounding[3]),
+            listOf(bounding[2], bounding[1]),
+            listOf(bounding[0], bounding[1]))
+
+    private fun bBoxToGeometry(bounding: List<Double>) = Geometry.Polygon(coordinates = listOf(bBoxToCoordinatList(bounding)))
+
+    fun distanceTo(f: Feature) : Double = distanceTo(f.bbox)
+
+    fun distanceTo(bb: MutableList<Double>) : Double {
+        var dist = bBoxToGeometry(bb).toJTS().distance(bBoxToGeometry(bbox).toJTS())
+        dist -= 0.5 * sqrt((bb[0] - bb[2]).pow(2.0) + (bb[1] - bb[3]).pow(2.0))
+        dist -= halfDiameter
+        return dist
+    }
+
+    fun getGeometry() = bBoxToGeometry(bbox)
+}

--- a/src/main/kotlin/io/marauder/tank/Region.kt
+++ b/src/main/kotlin/io/marauder/tank/Region.kt
@@ -3,15 +3,11 @@ package io.marauder.tank
 import io.marauder.charged.Projector
 import io.marauder.charged.models.Feature
 import io.marauder.charged.models.Geometry
-import org.slf4j.Logger
 import kotlin.math.pow
 import kotlin.math.sqrt
 
 
-class Region(
-        private val log: Logger
-) {
-
+class Region {
     var bbox =  mutableListOf<Double>()
     private val projector = Projector()
     private var halfDiameter = 0.0
@@ -27,6 +23,17 @@ class Region(
         }
     }
 
+    fun distanceTo(f: Feature) : Double = distanceTo(f.bbox)
+
+    fun distanceTo(bb: MutableList<Double>) : Double {
+        var dist = bBoxToGeometry(bb).toJTS().distance(bBoxToGeometry(bbox).toJTS())
+        dist -= getMinimalRadiusOfBoundingCircle(bb)
+        dist -= halfDiameter
+        return dist
+    }
+
+    fun getGeometry() = bBoxToGeometry(bbox)
+
     private fun add(bb: MutableList<Double>) {
         if(bbox.size == 0) {
             bbox = bb
@@ -34,7 +41,8 @@ class Region(
         else {
             projector.calcBbox(bBoxToCoordinatList(bb), bbox)
         }
-        halfDiameter = 0.5 * sqrt((bbox[0] - bbox[2]).pow(2.0) + (bbox[1] - bbox[3]).pow(2.0))
+
+        halfDiameter = getMinimalRadiusOfBoundingCircle(bbox)
         featureCount++
     }
 
@@ -47,14 +55,5 @@ class Region(
 
     private fun bBoxToGeometry(bounding: List<Double>) = Geometry.Polygon(coordinates = listOf(bBoxToCoordinatList(bounding)))
 
-    fun distanceTo(f: Feature) : Double = distanceTo(f.bbox)
-
-    fun distanceTo(bb: MutableList<Double>) : Double {
-        var dist = bBoxToGeometry(bb).toJTS().distance(bBoxToGeometry(bbox).toJTS())
-        dist -= 0.5 * sqrt((bb[0] - bb[2]).pow(2.0) + (bb[1] - bb[3]).pow(2.0))
-        dist -= halfDiameter
-        return dist
-    }
-
-    fun getGeometry() = bBoxToGeometry(bbox)
+    private fun getMinimalRadiusOfBoundingCircle(bb: MutableList<Double>) = 0.5 * sqrt((bb[0] - bb[2]).pow(2.0) + (bb[1] - bb[3]).pow(2.0))
 }

--- a/src/main/kotlin/io/marauder/tank/RegionManager.kt
+++ b/src/main/kotlin/io/marauder/tank/RegionManager.kt
@@ -1,0 +1,258 @@
+package io.marauder.tank
+
+import io.marauder.charged.Projector
+import io.marauder.charged.models.Feature
+import io.marauder.charged.models.Geometry
+import net.spy.memcached.MemcachedClient
+import org.slf4j.Logger
+import java.util.ArrayList
+
+
+class RegionManager(
+        private val cacheRegionCount: Int,
+        private val cacheRegionThreshold: Int,
+        private val memcachedEnabled: Boolean = false,
+        private val cacheZoomLevelEnd: Int,
+        private val mcc : MemcachedClient?,
+        private val log: Logger
+) {
+    private val regions = mutableListOf<Region>()
+    private val projector = Projector()
+
+    // Distance-Werte
+    private var biggestDistance = 0.0
+    private var shortestDistance = Double.MAX_VALUE
+    private var shortPair:Pair<Region, Region>? = null
+
+    // Debugging
+    private var removeTileRequests = 0
+    private var removeRequests = 0
+    private var mergedRegions = 0
+    private var featuresImported = 0
+    private var destroyedRegions = 0
+
+    fun add(f: Feature) {
+        if(!memcachedEnabled) return
+
+
+        featuresImported++
+        projector.calcBbox(f)
+        // Falls nicht alle Regionen gefüllt sind
+        if(regions.size < cacheRegionCount) {
+            val newRegion = addToRegions(f)
+            recalculateDistantces(newRegion)
+        }
+        // Falls es nur eine Region geben soll
+        else if(cacheRegionCount == 1) {
+            addInRegion(0, f)
+        }
+        else{
+            val index = lowestDistance(f)
+            if(index == -1) {
+                // Merge die nähsten Regionen und erstelle eine neu aus f
+                if(shortPair != null) {
+                    mergedRegions++
+                    shortPair?.first?.safeAdd(shortPair?.second)
+                    regions.remove(shortPair?.second)
+                    addToRegions(f)
+
+                    // Recalculiere alle Distanze-Werte
+                    biggestDistance = 0.0
+                    shortestDistance = Double.MAX_VALUE
+                    regions.forEach {r->recalculateDistantces(r)}
+                }
+            }
+            else {
+                // Füge f in region mit Index index ein.
+                addInRegion(index, f)
+
+                // Füge jeder Regionen, die in diesem Schritt nicht bearbeitet wurde einen Schritt im Zähler hinzu
+                // und überprüfe, dass die Gesamtzahl unter dem Schwellwert liegt. Wurde der Schwellwert überschritten
+                // Lösche die Region
+                val remove = mutableListOf<Region>()
+                for ((i, r) in regions.withIndex()) {
+                    if(index == i)
+                            r.distanceToLastStep = 0
+                    else {
+                        r.distanceToLastStep++
+                        if(r.distanceToLastStep > cacheRegionThreshold) {
+                            remove.add(r)
+                            invalCacheCV(regions[i].getGeometry())
+                        }
+                    }
+                }
+                remove.forEach { r ->
+                    regions.remove(r)
+                }
+                regions.forEach {r->recalculateDistantces(r)}
+                destroyedRegions += remove.size
+            }
+        }
+    }
+
+    // Sucht nach dem Index in der Region-Liste, in die das Feature f eingeflochten werden soll
+    // Gibt den Index zurück, oder -1, falls die Distanz des Features zu allen Regions größer ist
+    // als der größte Abstand zwischen den Regions
+    private fun lowestDistance(f: Feature): Int {
+        var lowDist = Double.MAX_VALUE
+        var index = -1
+
+        for ((i, r) in regions.withIndex()) {
+            val dist = r.distanceTo(f)
+            if(lowDist > dist){
+                lowDist = dist
+                index = i
+            }
+        }
+
+        if(lowDist > biggestDistance)
+            return -1
+
+        return index
+    }
+
+    private fun addToRegions(f: Feature): Region{
+        val newRegion = Region(log)
+        regions.add(newRegion)
+        newRegion.add(f)
+        return newRegion
+    }
+
+    private fun addInRegion(index:Int, f:Feature) {
+        regions[index].add(f)
+
+        if(regions[index].featureCount < cacheRegionThreshold)
+            recalculateDistantces(regions[index])
+        else {
+            invalCacheCV(regions[index].getGeometry())
+            regions.removeAt(index)
+            biggestDistance = 0.0
+            shortestDistance = Double.MAX_VALUE
+            regions.forEach {r->recalculateDistantces(r)}
+        }
+    }
+
+    private fun recalculateDistantces(region:Region) {
+        regions.forEach {r ->
+            if(region != r) {
+                val dist = r.distanceTo(region.bbox)
+                if(biggestDistance < dist)
+                    biggestDistance = dist
+
+                if(shortestDistance > dist){
+                    shortestDistance = dist
+                    shortPair = Pair(region, r)
+                }
+            }
+        }
+    }
+
+    fun flush() {
+        if(!memcachedEnabled) return
+
+        regions.forEach {r ->
+            invalCacheCV(r.getGeometry())
+        }
+        regions.clear()
+        log.info("Tile-Requests = $removeTileRequests  Remove-Requests = $removeRequests  Merge-Requests = $mergedRegions  Features-Imported: $featuresImported Destroyed Regions: $destroyedRegions")
+        removeRequests = 0
+        removeTileRequests = 0
+        mergedRegions = 0
+        featuresImported = 0
+    }
+
+    /**
+     * Top-Down
+     */
+    private fun invalidateCacheTD(geo : Geometry) {
+        removeRequests++
+        val tileLookUp = ArrayList<Tile>()
+
+        tileLookUp.add(Tile(0,0,0))
+
+        while(tileLookUp.isNotEmpty()) {
+            if(tileLookUp[0].z <= 21) {
+                if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
+                    tileLookUp.addAll(tileLookUp[0].getChildren())
+                    removeTile(tileLookUp[0])
+                }
+            }
+            tileLookUp.removeAt(0)
+        }
+
+    }
+
+
+    /**
+     * Covering
+     */
+    private fun invalCacheCV(geo : Geometry) {
+        removeRequests++
+        val tileLookUp = ArrayList<Tile>()
+
+        tileLookUp.add(Tile(0,0,0))
+
+        while(tileLookUp.isNotEmpty()) {
+            if(tileLookUp[0].z <= cacheZoomLevelEnd) {
+                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS())) {
+                    invalCacheAllChildren(tileLookUp[0])
+                }
+
+                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
+                    tileLookUp.addAll(tileLookUp[0].getChildren())
+                    removeTile(tileLookUp[0])
+                }
+            }
+            tileLookUp.removeAt(0)
+        }
+    }
+
+
+    /**
+     * ThreeQuarters
+     */
+    private fun invalCacheTQ(geo : Geometry) {
+        removeRequests++
+        val tileLookUp = ArrayList<Tile>()
+
+        tileLookUp.add(Tile(0,0,0))
+
+        while(tileLookUp.isNotEmpty()) {
+            if(tileLookUp[0].z <= cacheZoomLevelEnd) {
+                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS()) ||
+                        tileLookUp[0].getIntersection(geo) > 0.75
+                ) {
+                    invalCacheAllChildren(tileLookUp[0])
+                }
+
+                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
+                    tileLookUp.addAll(tileLookUp[0].getChildren())
+                    removeTile(tileLookUp[0])
+                }
+            }
+            tileLookUp.removeAt(0)
+        }
+    }
+
+    private fun invalCacheAllChildren(t : Tile) {
+        val queue = ArrayList<Tile>()
+
+        queue.add(t)
+
+        while(queue.isNotEmpty()) {
+            if(queue[0].z < cacheZoomLevelEnd) {
+                queue.addAll(queue[0].getChildren())
+            }
+            removeTile(queue[0])
+            queue.removeAt(0)
+        }
+    }
+
+    private fun removeTile(t : Tile) {
+        if(memcachedEnabled) {
+            mcc?.delete("heatmap/" + t.z + "/" + t.x + "/" + t.y)
+            mcc?.delete("tile/" + t.z + "/" + t.x + "/" + t.y)
+            removeTileRequests++
+        }
+    }
+}

--- a/src/main/kotlin/io/marauder/tank/RegionManager.kt
+++ b/src/main/kotlin/io/marauder/tank/RegionManager.kt
@@ -161,27 +161,6 @@ class RegionManager(
         featuresImported = 0
     }
 
-    /**
-     * Top-Down
-     */
-    private fun invalidateCacheTD(geo : Geometry) {
-        removeRequests++
-        val tileLookUp = ArrayList<Tile>()
-
-        tileLookUp.add(Tile(0,0,0))
-
-        while(tileLookUp.isNotEmpty()) {
-            if(tileLookUp[0].z <= 21) {
-                if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
-                    tileLookUp.addAll(tileLookUp[0].getChildren())
-                    removeTile(tileLookUp[0])
-                }
-            }
-            tileLookUp.removeAt(0)
-        }
-
-    }
-
 
     /**
      * Covering
@@ -195,33 +174,6 @@ class RegionManager(
         while(tileLookUp.isNotEmpty()) {
             if(tileLookUp[0].z <= cacheZoomLevelEnd) {
                 if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS())) {
-                    invalCacheAllChildren(tileLookUp[0])
-                }
-
-                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
-                    tileLookUp.addAll(tileLookUp[0].getChildren())
-                    removeTile(tileLookUp[0])
-                }
-            }
-            tileLookUp.removeAt(0)
-        }
-    }
-
-
-    /**
-     * ThreeQuarters
-     */
-    private fun invalCacheTQ(geo : Geometry) {
-        removeRequests++
-        val tileLookUp = ArrayList<Tile>()
-
-        tileLookUp.add(Tile(0,0,0))
-
-        while(tileLookUp.isNotEmpty()) {
-            if(tileLookUp[0].z <= cacheZoomLevelEnd) {
-                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS()) ||
-                        tileLookUp[0].getIntersection(geo) > 0.75
-                ) {
                     invalCacheAllChildren(tileLookUp[0])
                 }
 

--- a/src/main/kotlin/io/marauder/tank/Tile.kt
+++ b/src/main/kotlin/io/marauder/tank/Tile.kt
@@ -40,4 +40,16 @@ class Tile (val x: Int, val y: Int, val z: Int){
         return intersect.area / poly.toJTS().area
     }
 
+    override fun toString():String {
+        return "Tile($x,$y, $z)"
+    }
+
+    override fun equals(other: Any?): Boolean =
+        if (other is Tile) {
+            x == other.x && y == other.y && z == other.z
+        } else {
+            false
+        }
+
+
 }

--- a/src/main/kotlin/io/marauder/tank/Tyler.kt
+++ b/src/main/kotlin/io/marauder/tank/Tyler.kt
@@ -40,8 +40,8 @@ class Tyler(
     """.trimIndent())
 
     private val projector = Projector()
-    private val regionManager = RegionManager(chacheRegionCount, cacheRegionThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc, log)
-    private val boundingManager = BoundingManager(cacheBoundingThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc, log)
+    private val regionManager = RegionManager(chacheRegionCount, cacheRegionThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc)
+    private val boundingManager = BoundingManager(cacheBoundingThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc)
 
     private var delay = 0L
 
@@ -179,7 +179,7 @@ class Tyler(
     }
 
     fun closeCaching() {
-        regionManager.flush();
+        regionManager.flush()
         boundingManager.flush()
     }
 

--- a/src/main/kotlin/io/marauder/tank/Tyler.kt
+++ b/src/main/kotlin/io/marauder/tank/Tyler.kt
@@ -7,7 +7,6 @@ import com.datastax.driver.core.exceptions.QueryExecutionException
 import io.marauder.charged.Projector
 import io.marauder.charged.models.Feature
 import io.marauder.charged.models.GeoJSON
-import io.marauder.charged.models.Geometry
 import io.marauder.charged.models.Value
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -16,7 +15,6 @@ import kotlinx.serialization.ImplicitReflectionSerializer
 import net.spy.memcached.MemcachedClient
 import org.slf4j.LoggerFactory
 import java.lang.ClassCastException
-import java.util.concurrent.TimeUnit
 import java.util.*
 
 @ImplicitReflectionSerializer
@@ -27,8 +25,12 @@ class Tyler(
         private val attrFields: List<String>,
         private val hashLevel: Int,
         private val exhauster: Exhauster?,
-        private val memcachedEnabled: Boolean = false,
-        private val mcc : MemcachedClient?
+        memcachedEnabled: Boolean = false,
+        mcc : MemcachedClient?,
+        chacheRegionCount: Int,
+        cacheRegionThreshold: Int,
+        cacheZoomLevelEnd:Int,
+        cacheBoundingThreshold:Int
 ) {
 
     private val attributes = attrFields.map { it.split(" ").first() }
@@ -38,6 +40,8 @@ class Tyler(
     """.trimIndent())
 
     private val projector = Projector()
+    private val regionManager = RegionManager(chacheRegionCount, cacheRegionThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc, log)
+    private val boundingManager = BoundingManager(cacheBoundingThreshold, memcachedEnabled, cacheZoomLevelEnd, mcc, log)
 
     private var delay = 0L
 
@@ -132,12 +136,8 @@ class Tyler(
 
                 endLog()
 
-                val startTime = System.nanoTime()
-                invalidateCacheTD(f.geometry)
-                //incvalCacheCV(f.geometry)
-                //invalCacheTQ(f.geometry)
-                val duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
-                log.info("$duration ms")
+                regionManager.add(f)
+                //boundingManager.add(f)
 
                 endLog = marker.startLogDuration("store geometry to database")
                 delay(delay)
@@ -178,100 +178,14 @@ class Tyler(
         } while (true)
     }
 
+    fun closeCaching() {
+        regionManager.flush();
+        boundingManager.flush()
+    }
+
     companion object {
         private val log = LoggerFactory.getLogger(Tyler::class.java)
         private val marker = Benchmark(log)
-    }
-
-    /**
-     * Top-Down
-     */
-    private fun invalidateCacheTD(geo : Geometry) {
-        val tileLookUp = ArrayList<Tile>()
-
-        tileLookUp.add(Tile(0,0,0))
-
-        while(tileLookUp.isNotEmpty()) {
-            if(tileLookUp[0].z <= 21) {
-                if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
-                    tileLookUp.addAll(tileLookUp[0].getChildren())
-                    removeTile(tileLookUp[0])
-                }
-            }
-            tileLookUp.removeAt(0)
-        }
-
-    }
-
-
-    /**
-     * Covering
-     */
-    private fun incvalCacheCV(geo : Geometry) {
-        val tileLookUp = ArrayList<Tile>()
-
-        tileLookUp.add(Tile(0,0,0))
-
-        while(tileLookUp.isNotEmpty()) {
-            if(tileLookUp[0].z <= 21) {
-                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS())) {
-                    invalCacheAllChildren(tileLookUp[0])
-                }
-
-                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
-                    tileLookUp.addAll(tileLookUp[0].getChildren())
-                    removeTile(tileLookUp[0])
-                }
-            }
-            tileLookUp.removeAt(0)
-        }
-    }
-
-
-    /**
-     * ThreeQuarters
-     */
-    private fun invalCacheTQ(geo : Geometry) {
-        val tileLookUp = ArrayList<Tile>()
-
-        tileLookUp.add(Tile(0,0,0))
-
-        while(tileLookUp.isNotEmpty()) {
-            if(tileLookUp[0].z <= 21) {
-                if(tileLookUp[0].getGeometry().toJTS().coveredBy(geo.toJTS()) ||
-                                tileLookUp[0].getIntersection(geo) > 0.75
-                        ) {
-                    invalCacheAllChildren(tileLookUp[0])
-                }
-
-                else if(tileLookUp[0].getGeometry().toJTS().intersects(geo.toJTS())) {
-                    tileLookUp.addAll(tileLookUp[0].getChildren())
-                    removeTile(tileLookUp[0])
-                }
-            }
-            tileLookUp.removeAt(0)
-        }
-    }
-
-    private fun invalCacheAllChildren(t : Tile) {
-        val queue = ArrayList<Tile>()
-
-        queue.add(t)
-
-        while(queue.isNotEmpty()) {
-            if(queue[0].z < 21) {
-                queue.addAll(queue[0].getChildren())
-            }
-            removeTile(queue[0])
-            queue.removeAt(0)
-        }
-    }
-
-    private fun removeTile(t : Tile) {
-        if(memcachedEnabled) {
-            mcc?.delete("heatmap/" + t.z + "/" + t.x + "/" + t.y)
-            mcc?.delete("tile/" + t.z + "/" + t.x + "/" + t.y)
-        }
     }
 
 }


### PR DESCRIPTION
Adding a Clustering-Algorithm to the tank in the feature import process reduces the traffic to the Memcache. It clusters dynamically the imported features by analysing  the distance between existing clusters and the newly imported feature.  
For comparision there is another algorithm called Bounding. It calculates all updated Tiles by a newly imported Tiles. By collecting more than one feature in the list the traffic to the Memcache is reduced, but it is more RAM necessary than with the Cluster-Algorithm.